### PR TITLE
Pleasing static analyzer (Psalm)

### DIFF
--- a/src/Events/ModelChanged.php
+++ b/src/Events/ModelChanged.php
@@ -3,6 +3,7 @@
 namespace Panoscape\History\Events;
 
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Database\Eloquent\Model;
 
 class ModelChanged
 {


### PR DESCRIPTION
Otherwise [Psalm](https://psalm.dev) expects a non-existent `Panoscape\History\Events\Model` as `Model`. Thank you.