### PR TITLE
Revert "Laravel 11.x Compatibility"

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -1,73 +1,53 @@
 name: Test
-
 on:
   push:
-    branches:
-      - master
-    paths-ignore:
-      - **/*.md
+    branches: [master]
+    paths-ignore: ['**/*.md']
   pull_request:
-    branches:
-      - master
-    paths-ignore:
-      - **/*.md
-
+    branches: [master]
+    paths-ignore: ['**/*.md']
 jobs:
   run:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
-        laravel-versions: ['11.0', ^6.0, ^7.0, ^8.0, ^9.0, ^10.0]
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        laravel-versions: ["^6.0", "^7.0", "^8.0", "^9.0", "^10.0"]
+        php-versions: ["7.2", "7.3", "7.4", "8.0", "8.1"]
         exclude:
-          - laravel-versions: ^6.0
-            php-versions: '8.1'
-          - laravel-versions: ^7.0
-            php-versions: '8.1'
-          - laravel-versions: ^8.0
-            php-versions: '7.2'
-          - laravel-versions: ^9.0
-            php-versions: '7.2'
-          - laravel-versions: ^9.0
-            php-versions: '7.3'
-          - laravel-versions: ^9.0
-            php-versions: '7.4'
-          - laravel-versions: ^10.0
-            php-versions: '7.2'
-          - laravel-versions: ^10.0
-            php-versions: '7.3'
-          - laravel-versions: ^10.0
-            php-versions: '7.4'
-          - laravel-versions: ^10.0
-            php-versions: '8.0'
-          - laravel-versions: '11.0'
-            php-versions: '7.2'
-          - laravel-versions: '11.0'
-            php-versions: '7.3'
-          - laravel-versions: '11.0'
-            php-versions: '7.4'
-          - laravel-versions: '11.0'
-            php-versions: '8.0'
-          - laravel-versions: '11.0'
-            php-versions: '8.1'
-
+          - laravel-versions: "^6.0"
+            php-versions: "8.1"
+          - laravel-versions: "^7.0"
+            php-versions: "8.1"
+          - laravel-versions: "^8.0"
+            php-versions: "7.2"
+          - laravel-versions: "^9.0"
+            php-versions: "7.2"
+          - laravel-versions: "^9.0"
+            php-versions: "7.3"
+          - laravel-versions: "^9.0"
+            php-versions: "7.4"
+          - laravel-versions: "^10.0"
+            php-versions: "7.2"
+          - laravel-versions: "^10.0"
+            php-versions: "7.3"
+          - laravel-versions: "^10.0"
+            php-versions: "7.4"
+          - laravel-versions: "^10.0"
+            php-versions: "8.0"
     name: PHP ${{ matrix.php-versions }} with Laravel ${{ matrix.laravel-versions }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, dom, fileinfo
-
       - name: Install Composer dependencies
         run: |
           composer require --dev --no-progress --no-suggest -n -o "laravel/framework:${{ matrix.laravel-versions }}"
           composer install --no-progress --no-suggest -n -o
-
       - name: Run test suite
         run: composer test:dist
+      # - name: Run test coverage
+      #   run: composer test:coverage

--- a/composer.json
+++ b/composer.json
@@ -1,18 +1,11 @@
 {
     "name": "panoscape/history",
     "description": "Eloquent model history tracking for Laravel",
-    "keywords": [
-        "laravel",
-        "log",
-        "history",
-        "tracking",
-        "eloquent",
-        "model"
-    ],
+    "keywords": ["laravel", "log", "history", "tracking", "eloquent", "model"],
     "homepage": "https://github.com/seancheung/history",
     "require": {
         "php": "^7.2|^7.2.5|^7.3|^8.0|^8.1",
-        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0"
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0"
     },
     "license": "MIT",
     "authors": [
@@ -34,11 +27,11 @@
     "autoload-dev": {
         "psr-4": {
             "Panoscape\\History\\Tests\\": "tests/"
-        }
+        }  
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.3|^8.4|^9.0|^10.5",
-        "orchestra/testbench": "^4.8|^5.2|^6.2|^7.5|^8.0|^9.0",
+        "phpunit/phpunit": "^8.3|^8.4|^9.0",
+        "orchestra/testbench": "^4.8|^5.2|^6.2|^7.5|^8.0",
         "mockery/mockery": "^1.2",
         "php-coveralls/php-coveralls": "^2.1"
     },


### PR DESCRIPTION
Reverts seancheung/history#34

Reason:
- There are syntax errors in workflow file.
- Current phpunit xml file is incompatible with newer versions