### PR TITLE
bugfix: time() replaced with now()

### DIFF
--- a/src/HistoryObserver.php
+++ b/src/HistoryObserver.php
@@ -22,7 +22,7 @@ class HistoryObserver
             'meta' => $model->getModelMeta('created'),
             'user_id' => static::getUserID(),
             'user_type' => static::getUserType(),
-            'performed_at' => time(),
+            'performed_at' => now(),
         ]);
     }
 
@@ -58,7 +58,7 @@ class HistoryObserver
             'meta' => $meta,
             'user_id' => static::getUserID(),
             'user_type' => static::getUserType(),
-            'performed_at' => time(),
+            'performed_at' => now(),
         ]);
     }
 
@@ -77,7 +77,7 @@ class HistoryObserver
             'meta' => $model->getModelMeta('deleting'),
             'user_id' => static::getUserID(),
             'user_type' => static::getUserType(),
-            'performed_at' => time(),
+            'performed_at' => now(),
         ]);
     }
 
@@ -96,7 +96,7 @@ class HistoryObserver
             'meta' => $model->getModelMeta('restored'),
             'user_id' => static::getUserID(),
             'user_type' => static::getUserType(),
-            'performed_at' => time(),
+            'performed_at' => now(),
         ]);
     }
 

--- a/src/Listeners/HistoryEventSubscriber.php
+++ b/src/Listeners/HistoryEventSubscriber.php
@@ -23,7 +23,7 @@ class HistoryEventSubscriber
             'meta' => $event->meta,
             'user_id' => HistoryObserver::getUserID(),
             'user_type' => HistoryObserver::getUserType(),
-            'performed_at' => time(),
+            'performed_at' => now(),
         ]);
     }
 


### PR DESCRIPTION
Hi @seancheung ,

Maybe its only on my side, but time() function gives wrong hours (in my case -1 difference than actual).
I try to setup timezone in php.ini also in laravel config but no success.

Use carbon instead, more relevant.

Thanks.